### PR TITLE
fix: define the iframe size the same as inner content

### DIFF
--- a/src/client/iframe/iframe.ts
+++ b/src/client/iframe/iframe.ts
@@ -22,7 +22,7 @@ export class Iframe {
       sandbox:
         'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation',
       style:
-        'display: none; border: none; width: 100%; height: 100%; max-width: 500px; min-width: min(500px, 100%); overflow: hidden; margin: auto;',
+        'display: none; border: none; width: 100%; height: 100%; max-width: 396px; min-width: min(396px, 100%); overflow: hidden; margin: auto;',
     };
 
     // Apply default attributes


### PR DESCRIPTION
## Summary
fix: define the iframe size the same as inner content

## Changes
- updated iframe element style

## Testing
Locally.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
