### PR TITLE
fix: properly cleanup iframe and container on dispose

### DIFF
--- a/src/client/iframe/iframe.ts
+++ b/src/client/iframe/iframe.ts
@@ -58,11 +58,9 @@ export class Iframe {
   }
 
   public dispose(): void {
-    if (this.element && this.element.parentElement) {
-      // Remove iframe from the DOM
-      this.element.parentElement.removeChild(this.element);
+    if (this.element?.parentElement) {
       // Remove container div from the DOM
-      this.element.parentElement.remove();
+      this.element.parentElement?.remove();
     }
 
     if (this.loader) {


### PR DESCRIPTION
## Summary

This PR fixes an issue with the cleanup process of iframe and container elements when the dispose method is called, preventing potential memory leaks and DOM pollution.

## Changes

- 3d7951b: fix: properly cleanup iframe and container on dispose
  - Improved the cleanup logic in the iframe.ts file to ensure proper removal of elements from the DOM
  - Fixed potential null reference issues by using optional chaining

## Testing

Locally for Testing.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.