### PR TITLE
Remove white background from iframe element

### DIFF
--- a/src/client/iframe/iframe.ts
+++ b/src/client/iframe/iframe.ts
@@ -34,7 +34,7 @@ export class Iframe {
       sandbox:
         'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation',
       style:
-        'display: block; border: none; width: 100%; height: 100%; min-height: 326px; max-width: 396px; min-width: min(396px, 100%); overflow: hidden; margin: auto; background-color: white;',
+        'display: block; border: none; width: 100%; height: 100%; min-height: 326px; max-width: 396px; min-width: min(396px, 100%); overflow: hidden; margin: auto;',
     };
 
     // Apply default attributes


### PR DESCRIPTION
## Summary
This PR removes the white background color from the iframe element, allowing the iframe to inherit background color from its parent or use the default transparent background.

## Changes
- Removed the `background-color: white;` style property from the iframe element in `src/client/iframe/iframe.ts`

## Testing
The change can be tested by verifying that the iframe no longer has a forced white background and instead displays with either a transparent background or inherits background styling from parent elements.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.