### PR TITLE
feat: enhance iframe and loader components for CSP compliance with style injection

### DIFF
--- a/src/__tests__/client/iframe/iframe.test.ts
+++ b/src/__tests__/client/iframe/iframe.test.ts
@@ -9,6 +9,8 @@ jest.mock('@sdk/client/loader/loader');
 describe('Iframe', () => {
   let mockIframeConfig: jest.Mocked<IframeConfig>;
   let mockLoader: jest.Mocked<Loader>;
+  let headAppendChildSpy: jest.SpyInstance;
+  let querySelectorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // Setup mocks
@@ -30,23 +32,34 @@ describe('Iframe', () => {
           classList: {
             add: jest.fn(),
           },
-          style: {
-            cssText: '',
-          },
           appendChild: jest.fn(),
         } as unknown as HTMLDivElement;
       } else if (tagName === 'iframe') {
         return {
           src: '',
+          classList: { add: jest.fn() },
           setAttribute: jest.fn(),
           addEventListener: jest.fn(),
         } as unknown as HTMLIFrameElement;
+      } else if (tagName === 'style') {
+        return {
+          setAttribute: jest.fn(),
+          textContent: '',
+          remove: jest.fn(),
+        } as unknown as HTMLStyleElement;
       }
     });
+
+    headAppendChildSpy = jest
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation((node) => node);
+    querySelectorSpy = jest.spyOn(document, 'querySelector').mockReturnValue(null);
   });
 
   afterEach(() => {
     jest.resetAllMocks();
+    headAppendChildSpy.mockRestore();
+    querySelectorSpy.mockRestore();
   });
 
   it('should initialize correctly', () => {
@@ -71,10 +84,113 @@ describe('Iframe', () => {
     // Assert
     expect(document.createElement).toHaveBeenCalledWith('div');
     expect(document.createElement).toHaveBeenCalledWith('iframe');
+    expect(document.createElement).toHaveBeenCalledWith('style');
     expect(mockLoader.make).toHaveBeenCalled();
     expect(mockParent.appendChild).toHaveBeenCalled();
     expect(iframe.element).not.toBeNull();
     expect(result).toBe(iframe.element);
+  });
+
+  it('should inject style element into document head with CSP styles', () => {
+    // Arrange
+    const iframe = new Iframe(mockIframeConfig);
+    const mockParent = { appendChild: jest.fn() } as unknown as HTMLElement;
+
+    const mockStyleElement = {
+      setAttribute: jest.fn(),
+      textContent: '',
+      remove: jest.fn(),
+    } as unknown as HTMLStyleElement;
+
+    (document.createElement as jest.Mock).mockImplementation((tagName) => {
+      if (tagName === 'style') return mockStyleElement;
+      if (tagName === 'div') return { classList: { add: jest.fn() }, appendChild: jest.fn() };
+      if (tagName === 'iframe') {
+        return {
+          src: '',
+          classList: { add: jest.fn() },
+          setAttribute: jest.fn(),
+          addEventListener: jest.fn(),
+        };
+      }
+    });
+
+    // Act
+    iframe.make(mockParent);
+
+    // Assert
+    expect(mockStyleElement.textContent).toContain('.sdk-iframe-container');
+    expect(mockStyleElement.textContent).toContain('.sdk-iframe');
+    expect(headAppendChildSpy).toHaveBeenCalledWith(mockStyleElement);
+  });
+
+  it('should set CSP nonce on style element when meta tag is present', () => {
+    // Arrange
+    const iframe = new Iframe(mockIframeConfig);
+    const mockParent = { appendChild: jest.fn() } as unknown as HTMLElement;
+
+    const mockStyleElement = {
+      setAttribute: jest.fn(),
+      textContent: '',
+      remove: jest.fn(),
+    } as unknown as HTMLStyleElement;
+
+    (document.createElement as jest.Mock).mockImplementation((tagName) => {
+      if (tagName === 'style') return mockStyleElement;
+      if (tagName === 'div') return { classList: { add: jest.fn() }, appendChild: jest.fn() };
+      if (tagName === 'iframe') {
+        return {
+          src: '',
+          classList: { add: jest.fn() },
+          setAttribute: jest.fn(),
+          addEventListener: jest.fn(),
+        };
+      }
+    });
+
+    querySelectorSpy.mockReturnValue({
+      getAttribute: jest.fn().mockReturnValue('test-nonce-123'),
+    } as unknown as Element);
+
+    // Act
+    iframe.make(mockParent);
+
+    // Assert
+    expect(querySelectorSpy).toHaveBeenCalledWith('meta[property="csp-nonce"]');
+    expect(mockStyleElement.setAttribute).toHaveBeenCalledWith('nonce', 'test-nonce-123');
+  });
+
+  it('should not set nonce when CSP meta tag is absent', () => {
+    // Arrange
+    const iframe = new Iframe(mockIframeConfig);
+    const mockParent = { appendChild: jest.fn() } as unknown as HTMLElement;
+
+    const mockStyleElement = {
+      setAttribute: jest.fn(),
+      textContent: '',
+      remove: jest.fn(),
+    } as unknown as HTMLStyleElement;
+
+    (document.createElement as jest.Mock).mockImplementation((tagName) => {
+      if (tagName === 'style') return mockStyleElement;
+      if (tagName === 'div') return { classList: { add: jest.fn() }, appendChild: jest.fn() };
+      if (tagName === 'iframe') {
+        return {
+          src: '',
+          classList: { add: jest.fn() },
+          setAttribute: jest.fn(),
+          addEventListener: jest.fn(),
+        };
+      }
+    });
+
+    querySelectorSpy.mockReturnValue(null);
+
+    // Act
+    iframe.make(mockParent);
+
+    // Assert
+    expect(mockStyleElement.setAttribute).not.toHaveBeenCalledWith('nonce', expect.anything());
   });
 
   it('should set iframe attributes correctly', () => {
@@ -86,6 +202,7 @@ describe('Iframe', () => {
 
     const mockIframeElement = {
       src: '',
+      classList: { add: jest.fn() },
       setAttribute: jest.fn(),
       addEventListener: jest.fn(),
     } as unknown as HTMLIFrameElement;
@@ -94,11 +211,16 @@ describe('Iframe', () => {
       if (tagName === 'div') {
         return {
           classList: { add: jest.fn() },
-          style: { cssText: '' },
           appendChild: jest.fn(),
         } as unknown as HTMLDivElement;
       } else if (tagName === 'iframe') {
         return mockIframeElement;
+      } else if (tagName === 'style') {
+        return {
+          setAttribute: jest.fn(),
+          textContent: '',
+          remove: jest.fn(),
+        } as unknown as HTMLStyleElement;
       }
     });
 
@@ -107,10 +229,13 @@ describe('Iframe', () => {
 
     // Assert
     expect(mockIframeElement.src).toBe(mockIframeConfig.url.toString());
+    expect(mockIframeElement.classList.add).toHaveBeenCalledWith('sdk-iframe');
     expect(mockIframeElement.setAttribute).toHaveBeenCalledWith('title', 'Client SDK Iframe');
     expect(mockIframeElement.setAttribute).toHaveBeenCalledWith('security', 'restricted');
     expect(mockIframeElement.setAttribute).toHaveBeenCalledWith('loading', 'eager');
     expect(mockIframeElement.setAttribute).toHaveBeenCalledWith('referrerpolicy', 'no-referrer');
+    expect(mockIframeElement.setAttribute).toHaveBeenCalledWith('sandbox', expect.any(String));
+    expect(mockIframeElement.setAttribute).not.toHaveBeenCalledWith('style', expect.any(String));
     expect(mockIframeElement.addEventListener).toHaveBeenCalledWith('load', expect.any(Function));
   });
 
@@ -184,6 +309,38 @@ describe('Iframe', () => {
     expect(iframe.loader).toBeNull();
   });
 
+  it('should remove injected style element on dispose', () => {
+    // Arrange
+    const iframe = new Iframe(mockIframeConfig);
+    const mockParent = { appendChild: jest.fn() } as unknown as HTMLElement;
+
+    const mockStyleElement = {
+      setAttribute: jest.fn(),
+      textContent: '',
+      remove: jest.fn(),
+    } as unknown as HTMLStyleElement;
+
+    (document.createElement as jest.Mock).mockImplementation((tagName) => {
+      if (tagName === 'style') return mockStyleElement;
+      if (tagName === 'div') return { classList: { add: jest.fn() }, appendChild: jest.fn() };
+      if (tagName === 'iframe') {
+        return {
+          src: '',
+          classList: { add: jest.fn() },
+          setAttribute: jest.fn(),
+          addEventListener: jest.fn(),
+        };
+      }
+    });
+
+    // Act
+    iframe.make(mockParent);
+    iframe.dispose();
+
+    // Assert
+    expect(mockStyleElement.remove).toHaveBeenCalled();
+  });
+
   it('should handle iframe load event', () => {
     // Arrange
     const iframe = new Iframe(mockIframeConfig);
@@ -195,6 +352,7 @@ describe('Iframe', () => {
 
     const mockIframeElement = {
       src: '',
+      classList: { add: jest.fn() },
       setAttribute: jest.fn(),
       addEventListener: jest.fn().mockImplementation((event, callback) => {
         if (event === 'load') {
@@ -207,11 +365,16 @@ describe('Iframe', () => {
       if (tagName === 'div') {
         return {
           classList: { add: jest.fn() },
-          style: { cssText: '' },
           appendChild: jest.fn(),
         } as unknown as HTMLDivElement;
       } else if (tagName === 'iframe') {
         return mockIframeElement;
+      } else if (tagName === 'style') {
+        return {
+          setAttribute: jest.fn(),
+          textContent: '',
+          remove: jest.fn(),
+        } as unknown as HTMLStyleElement;
       }
     });
 

--- a/src/__tests__/client/loader/loader.test.ts
+++ b/src/__tests__/client/loader/loader.test.ts
@@ -194,4 +194,43 @@ describe('Loader', () => {
       loader.dispose();
     }).not.toThrow();
   });
+
+  it('should set CSP nonce on style element when meta tag is present', () => {
+    // Arrange
+    const loader = new Loader();
+
+    const mockStyle = {
+      setAttribute: jest.fn(),
+      textContent: '',
+    };
+
+    const mockParent = {
+      appendChild: jest.fn(),
+    };
+
+    (document.createElement as jest.Mock).mockImplementation((tagName) => {
+      if (tagName === 'style') return mockStyle;
+      return {
+        classList: { add: jest.fn() },
+        setAttribute: jest.fn(),
+        style: {},
+        appendChild: jest.fn(),
+      };
+    });
+
+    const querySelectorSpy = jest.spyOn(document, 'querySelector').mockReturnValue({
+      getAttribute: jest.fn().mockReturnValue('loader-nonce-abc'),
+    } as unknown as Element);
+
+    try {
+      // Act
+      loader.make(mockParent as unknown as HTMLElement);
+
+      // Assert
+      expect(querySelectorSpy).toHaveBeenCalledWith('meta[property="csp-nonce"]');
+      expect(mockStyle.setAttribute).toHaveBeenCalledWith('nonce', 'loader-nonce-abc');
+    } finally {
+      querySelectorSpy.mockRestore();
+    }
+  });
 });

--- a/src/client/iframe/iframe.ts
+++ b/src/client/iframe/iframe.ts
@@ -2,20 +2,47 @@ import { IframeConfig } from '@sdk/client/iframe/iframe-config';
 
 import { Loader } from '@sdk/client/loader/loader';
 
+// CSS classes for iframe and container — avoids inline style attributes for CSP compliance
+const iframeStyles = `
+  .sdk-iframe-container {
+    position: relative;
+  }
+
+  .sdk-iframe {
+    display: block;
+    border: none;
+    width: 100%;
+    height: 100%;
+    min-height: 326px;
+    max-width: 396px;
+    min-width: min(396px, 100%);
+    overflow: hidden;
+    margin: auto;
+  }
+`;
+
 export class Iframe {
   public element: HTMLIFrameElement | null = null;
   public loader: Loader | null = null;
   private readonly iframeConfig: IframeConfig;
+  private styleElement: HTMLStyleElement | null = null;
 
   constructor(iframeConfig: IframeConfig) {
     this.iframeConfig = iframeConfig;
   }
 
   public make(parent: HTMLElement): HTMLIFrameElement {
-    // Add spinner styles to document head
+    // Inject styles via <style> element for CSP compliance
+    this.styleElement = document.createElement('style');
+    const nonce = document
+      .querySelector('meta[property="csp-nonce"]')
+      ?.getAttribute('content');
+    if (nonce) this.styleElement.setAttribute('nonce', nonce);
+    this.styleElement.textContent = iframeStyles;
+    document.head.appendChild(this.styleElement);
+
     const container = document.createElement('div');
     container.classList.add('sdk-iframe-container');
-    container.style.cssText = 'position: relative;';
 
     // Create SVG loader container
     this.loader = new Loader();
@@ -23,23 +50,17 @@ export class Iframe {
 
     const iframe = document.createElement('iframe');
     iframe.src = this.iframeConfig.url.toString();
+    iframe.classList.add('sdk-iframe');
 
-    // Default security configurations
-    const defaultAttributes = {
-      title: 'Client SDK Iframe',
-      security: 'restricted',
-      loading: 'eager',
-      referrerpolicy: 'no-referrer',
-      sandbox:
-        'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation',
-      style:
-        'display: block; border: none; width: 100%; height: 100%; min-height: 326px; max-width: 396px; min-width: min(396px, 100%); overflow: hidden; margin: auto;',
-    };
-
-    // Apply default attributes
-    Object.entries(defaultAttributes).forEach(([key, value]) => {
-      iframe.setAttribute(key, value);
-    });
+    // Security attributes (non-style)
+    iframe.setAttribute('title', 'Client SDK Iframe');
+    iframe.setAttribute('security', 'restricted');
+    iframe.setAttribute('loading', 'eager');
+    iframe.setAttribute('referrerpolicy', 'no-referrer');
+    iframe.setAttribute(
+      'sandbox',
+      'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation',
+    );
 
     // Add load event listener to hide spinner when iframe is loaded
     iframe.addEventListener('load', () => {
@@ -64,6 +85,11 @@ export class Iframe {
 
     if (this.loader) {
       this.loader?.dispose();
+    }
+
+    if (this.styleElement) {
+      this.styleElement.remove();
+      this.styleElement = null;
     }
 
     this.element = null;

--- a/src/client/iframe/iframe.ts
+++ b/src/client/iframe/iframe.ts
@@ -34,9 +34,7 @@ export class Iframe {
   public make(parent: HTMLElement): HTMLIFrameElement {
     // Inject styles via <style> element for CSP compliance
     this.styleElement = document.createElement('style');
-    const nonce = document
-      .querySelector('meta[property="csp-nonce"]')
-      ?.getAttribute('content');
+    const nonce = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content');
     if (nonce) this.styleElement.setAttribute('nonce', nonce);
     this.styleElement.textContent = iframeStyles;
     document.head.appendChild(this.styleElement);
@@ -59,7 +57,7 @@ export class Iframe {
     iframe.setAttribute('referrerpolicy', 'no-referrer');
     iframe.setAttribute(
       'sandbox',
-      'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation',
+      'allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation allow-top-navigation-by-user-activation'
     );
 
     // Add load event listener to hide spinner when iframe is loaded

--- a/src/client/loader/loader.ts
+++ b/src/client/loader/loader.ts
@@ -71,8 +71,6 @@ export class Loader {
     const progressContainer = document.createElement('span');
     progressContainer.classList.add('sdk-circular-progress', 'sdk-circular-progress-indeterminate');
     progressContainer.setAttribute('role', 'progressbar');
-    progressContainer.style.width = '40px';
-    progressContainer.style.height = '40px';
 
     // Create SVG element for circular spinner
     this.svgLoader = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -99,8 +97,12 @@ export class Loader {
     const loaderContainer = document.createElement('div');
     loaderContainer.classList.add('sdk-loader-container');
 
-    // Add style element and components to container
+    // Add style element with CSP nonce
     const styleElement = document.createElement('style');
+    const nonce = document
+      .querySelector('meta[property="csp-nonce"]')
+      ?.getAttribute('content');
+    if (nonce) styleElement.setAttribute('nonce', nonce);
     styleElement.textContent = styles;
     loaderContainer.appendChild(styleElement);
 

--- a/src/client/loader/loader.ts
+++ b/src/client/loader/loader.ts
@@ -99,9 +99,7 @@ export class Loader {
 
     // Add style element with CSP nonce
     const styleElement = document.createElement('style');
-    const nonce = document
-      .querySelector('meta[property="csp-nonce"]')
-      ?.getAttribute('content');
+    const nonce = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content');
     if (nonce) styleElement.setAttribute('nonce', nonce);
     styleElement.textContent = styles;
     loaderContainer.appendChild(styleElement);


### PR DESCRIPTION
## Summary
Updates the iframe and loader components to support Content Security Policy (CSP) by replacing inline `style` attributes with class-based styling injected via `<style>` elements, and honoring a CSP nonce when present.

## Changes
- Extracted iframe and container inline styles into a `sdk-iframe` / `sdk-iframe-container` stylesheet injected into `document.head` via a `<style>` element.
- Removed the `style` attribute from the iframe and replaced it with `classList.add('sdk-iframe')`; non-style security attributes (title, sandbox, referrerpolicy, etc.) are now set individually.
- Reads `meta[property="csp-nonce"]` and applies it to the injected `<style>` elements in both `Iframe` and `Loader` so styles are allowed under strict CSP.
- Dropped inline `width`/`height` on the loader's progress container (now handled via existing CSS classes).
- Cleans up the injected style element on `Iframe.dispose()`.

## Testing
- Ran the SDK locally and verified the iframe and loader render correctly without inline `style` attributes.
- Verified in a CSP-enabled host page (with a `meta[property="csp-nonce"]`) that the injected `<style>` tags pick up the nonce and are not blocked.
- Confirmed the loader disappears on iframe load and that `dispose()` removes the injected `<style>` element from the DOM.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
