### PR TITLE
chore: update repository URL format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VerifiedInc/client-sdk.git"
+    "url": "git+https://github.com/VerifiedInc/client-sdk.git"
   },
   "type": "module",
   "main": "./dist/index.esm.js",


### PR DESCRIPTION
## Summary
Updates the `repository.url` field in `package.json` to use the `git+https://` prefix, aligning with npm's recommended repository URL format.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
