### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+# Auto-approve and auto-merge Dependabot PRs for minor/patch updates only.
+# Majors are excluded — they arrive as individual PRs for human review.
+# Safe because the main ruleset requires green status checks before merge:
+# --auto waits for CI. ref: Linear ENG-17, ENG-190
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml`, copied from one-click-web-client (`fetch-metadata` pinned at v3.1.0). It auto-approves and enables squash auto-merge on minor/patch Dependabot PRs; majors are left open for human review.

## Why

Per [ENG-190](https://linear.app/verified-network/issue/ENG-190): our written SOC 2 position is that minor/patch dependency updates auto-merge behind a CI gate, but this repo never had the workflow at all — Dependabot PRs (e.g. #40, a security update) sat open until merged manually. The repo-level **Allow auto-merge** setting has already been enabled.

## CI gate

The `default` ruleset on `main` is being updated to require the existing `Build`, `Lint and Type Check`, and `Test` checks, so `--auto` waits for green CI — same shape as one-click-web-client's ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)